### PR TITLE
Add person search, transaction creation, capture-date, and FluentValidation

### DIFF
--- a/InteractiveMVC_Tables_With_Data.sql
+++ b/InteractiveMVC_Tables_With_Data.sql
@@ -28,6 +28,7 @@ CREATE TABLE Transactions (
     Amount DECIMAL(18, 2) NOT NULL,
     TransactionType VARCHAR(10) NOT NULL CHECK (TransactionType IN ('Debit', 'Credit')),
     TransactionDate DATETIME NOT NULL,
+    CaptureDate DATETIME NOT NULL,
     Description NVARCHAR(255),
     ActiveInd BIT NOT NULL,
     FOREIGN KEY (AccountId) REFERENCES Account(AccountId)
@@ -61,11 +62,11 @@ VALUES
     ('C11B7553-085C-4126-A128-F083E887A087', '23C43FE1-0B33-4530-B045-47B4CFEF230D', 'ACC3456789012', 'Checking', 500.75, 1, 0);
 
 	-- Insert test data into the Transactions table
-INSERT INTO Transactions (TransactionId, AccountId, Amount, TransactionType, TransactionDate, Description, ActiveInd)
+INSERT INTO Transactions (TransactionId, AccountId, Amount, TransactionType, TransactionDate, CaptureDate, Description, ActiveInd)
 VALUES
-    (NEWID(), 'D0300D5A-52FE-4B02-8844-78E9CC69769A', 100.00, 'Credit', '2024-07-01', 'Initial deposit', 1),
-    (NEWID(), 'D9771B65-BCE2-47C7-B611-A0C30FEDCF68', 50.75, 'Debit', '2024-07-02', 'Grocery shopping', 1),
-    (NEWID(), 'C11B7553-085C-4126-A128-F083E887A087', 200.00, 'Credit', '2024-07-03', 'Salary', 1);
+    (NEWID(), 'D0300D5A-52FE-4B02-8844-78E9CC69769A', 100.00, 'Credit', '2024-07-01', '2024-07-01', 'Initial deposit', 1),
+    (NEWID(), 'D9771B65-BCE2-47C7-B611-A0C30FEDCF68', 50.75, 'Debit', '2024-07-02', '2024-07-02', 'Grocery shopping', 1),
+    (NEWID(), 'C11B7553-085C-4126-A128-F083E887A087', 200.00, 'Credit', '2024-07-03', '2024-07-03', 'Salary', 1);
 
 -- Insert test data into Users Table
 	INSERT INTO Users (UserId, FirstName, LastName, Email, password,Role, ActiveInd)

--- a/RealRelianceBanking.Application/Accounts/Commands/AddAccount/CreateAccountCommandValidator.cs
+++ b/RealRelianceBanking.Application/Accounts/Commands/AddAccount/CreateAccountCommandValidator.cs
@@ -1,0 +1,24 @@
+using FluentValidation;
+
+namespace RealRelianceBanking.Application.Accounts.Commands.AddAccount
+{
+    public class CreateAccountCommandValidator : AbstractValidator<CreateAccountCommand>
+    {
+        public CreateAccountCommandValidator()
+        {
+            RuleFor(x => x.PersonId)
+                .NotEmpty();
+
+            RuleFor(x => x.AccountNumber)
+                .NotEmpty()
+                .MaximumLength(20);
+
+            RuleFor(x => x.AccountType)
+                .NotEmpty()
+                .MaximumLength(50);
+
+            RuleFor(x => x.Balance)
+                .GreaterThanOrEqualTo(0);
+        }
+    }
+}

--- a/RealRelianceBanking.Application/Common/Behaviors/ValidationBehavior.cs
+++ b/RealRelianceBanking.Application/Common/Behaviors/ValidationBehavior.cs
@@ -1,0 +1,43 @@
+using FluentValidation;
+using MediatR;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace RealRelianceBanking.Application.Common.Behaviors
+{
+    public class ValidationBehavior<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>
+        where TRequest : IRequest<TResponse>
+    {
+        private readonly IEnumerable<IValidator<TRequest>> _validators;
+
+        public ValidationBehavior(IEnumerable<IValidator<TRequest>> validators)
+        {
+            _validators = validators;
+        }
+
+        public async Task<TResponse> Handle(
+            TRequest request,
+            RequestHandlerDelegate<TResponse> next,
+            CancellationToken cancellationToken)
+        {
+            if (_validators.Any())
+            {
+                var context = new ValidationContext<TRequest>(request);
+                var failures = _validators
+                    .Select(validator => validator.Validate(context))
+                    .SelectMany(result => result.Errors)
+                    .Where(failure => failure != null)
+                    .ToList();
+
+                if (failures.Count != 0)
+                {
+                    throw new ValidationException(failures);
+                }
+            }
+
+            return await next();
+        }
+    }
+}

--- a/RealRelianceBanking.Application/Common/Interfaces/Persistance/IPersonRepository.cs
+++ b/RealRelianceBanking.Application/Common/Interfaces/Persistance/IPersonRepository.cs
@@ -28,5 +28,7 @@ namespace RealRelianceBanking.Application.Common.Interfaces.Persistance
 
         Task<bool> Update(EditPersonCommand person);
 
+        Task<List<PersonModel>> SearchPersons(int? idNumber, string? lastName, string? accountNumber);
+
     }
 }

--- a/RealRelianceBanking.Application/DependencyInjection.cs
+++ b/RealRelianceBanking.Application/DependencyInjection.cs
@@ -1,5 +1,7 @@
-﻿using MediatR;
+using FluentValidation;
+using MediatR;
 using Microsoft.Extensions.DependencyInjection;
+using RealRelianceBanking.Application.Common.Behaviors;
 
 namespace RealRelianceBanking.Application
 {
@@ -7,8 +9,12 @@ namespace RealRelianceBanking.Application
     {
         public static IServiceCollection AddApplication(this IServiceCollection services)
         {
-            services.AddMediatR(typeof(DependencyInjection).Assembly);
-            services.AddMediatR(AppDomain.CurrentDomain.GetAssemblies());
+            services.AddValidatorsFromAssembly(typeof(DependencyInjection).Assembly);
+            services.AddMediatR(config =>
+            {
+                config.RegisterServicesFromAssembly(typeof(DependencyInjection).Assembly);
+                config.AddOpenBehavior(typeof(ValidationBehavior<,>));
+            });
             return services;
         }
     }

--- a/RealRelianceBanking.Application/Person/Command/CreatePerson/CreatePersonCommandValidator.cs
+++ b/RealRelianceBanking.Application/Person/Command/CreatePerson/CreatePersonCommandValidator.cs
@@ -1,0 +1,30 @@
+using FluentValidation;
+
+namespace RealRelianceBanking.Application.Person.Command.CreatePerson
+{
+    public class CreatePersonCommandValidator : AbstractValidator<CreatePersonCommand>
+    {
+        public CreatePersonCommandValidator()
+        {
+            RuleFor(x => x.IdNumber)
+                .GreaterThan(0);
+
+            RuleFor(x => x.FirstName)
+                .NotEmpty()
+                .MaximumLength(100);
+
+            RuleFor(x => x.LastName)
+                .NotEmpty()
+                .MaximumLength(100);
+
+            RuleFor(x => x.Email)
+                .NotEmpty()
+                .EmailAddress()
+                .MaximumLength(100);
+
+            RuleFor(x => x.PhoneNumber)
+                .MaximumLength(15)
+                .When(x => !string.IsNullOrWhiteSpace(x.PhoneNumber));
+        }
+    }
+}

--- a/RealRelianceBanking.Application/Person/Command/EditPerson/EditPersonCommandValidator.cs
+++ b/RealRelianceBanking.Application/Person/Command/EditPerson/EditPersonCommandValidator.cs
@@ -1,0 +1,33 @@
+using FluentValidation;
+
+namespace RealRelianceBanking.Application.Person.Command.EditPerson
+{
+    public class EditPersonCommandValidator : AbstractValidator<EditPersonCommand>
+    {
+        public EditPersonCommandValidator()
+        {
+            RuleFor(x => x.personId)
+                .NotEmpty();
+
+            RuleFor(x => x.IdNumber)
+                .GreaterThan(0);
+
+            RuleFor(x => x.FirstName)
+                .NotEmpty()
+                .MaximumLength(100);
+
+            RuleFor(x => x.LastName)
+                .NotEmpty()
+                .MaximumLength(100);
+
+            RuleFor(x => x.Email)
+                .NotEmpty()
+                .EmailAddress()
+                .MaximumLength(100);
+
+            RuleFor(x => x.PhoneNumber)
+                .MaximumLength(15)
+                .When(x => !string.IsNullOrWhiteSpace(x.PhoneNumber));
+        }
+    }
+}

--- a/RealRelianceBanking.Application/Person/Queries/SearchPersons/SearchPersonsQuery.cs
+++ b/RealRelianceBanking.Application/Person/Queries/SearchPersons/SearchPersonsQuery.cs
@@ -1,0 +1,9 @@
+using MediatR;
+using RealRelianceBanking.Domain.Entities;
+using System.Collections.Generic;
+
+namespace RealRelianceBanking.Application.Person.Queries.SearchPersons
+{
+    public record SearchPersonsQuery(int? IdNumber, string? LastName, string? AccountNumber)
+        : IRequest<List<PersonModel>>;
+}

--- a/RealRelianceBanking.Application/Person/Queries/SearchPersons/SearchPersonsQueryHandler.cs
+++ b/RealRelianceBanking.Application/Person/Queries/SearchPersons/SearchPersonsQueryHandler.cs
@@ -1,0 +1,24 @@
+using MediatR;
+using RealRelianceBanking.Application.Common.Interfaces.Persistance;
+using RealRelianceBanking.Domain.Entities;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace RealRelianceBanking.Application.Person.Queries.SearchPersons
+{
+    public class SearchPersonsQueryHandler : IRequestHandler<SearchPersonsQuery, List<PersonModel>>
+    {
+        private readonly IPersonRepository _personRepository;
+
+        public SearchPersonsQueryHandler(IPersonRepository personRepository)
+        {
+            _personRepository = personRepository;
+        }
+
+        public Task<List<PersonModel>> Handle(SearchPersonsQuery request, CancellationToken cancellationToken)
+        {
+            return _personRepository.SearchPersons(request.IdNumber, request.LastName, request.AccountNumber);
+        }
+    }
+}

--- a/RealRelianceBanking.Application/RealRelianceBanking.Application.csproj
+++ b/RealRelianceBanking.Application/RealRelianceBanking.Application.csproj
@@ -7,6 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="FluentValidation" Version="11.10.0" />
+    <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.10.0" />
     <PackageReference Include="MediatR" Version="11.1.0" />
     <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="11.1.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="7.0.0" />

--- a/RealRelianceBanking.Application/Transactions/Command/Create/CreateTransactionCommand.cs
+++ b/RealRelianceBanking.Application/Transactions/Command/Create/CreateTransactionCommand.cs
@@ -1,0 +1,12 @@
+using MediatR;
+using System;
+
+namespace RealRelianceBanking.Application.Transactions.Command.Create
+{
+    public record CreateTransactionCommand(
+        Guid AccountId,
+        DateTime TransactionDate,
+        decimal Amount,
+        string TransactionType,
+        string Description) : IRequest<CreateTransactionResult>;
+}

--- a/RealRelianceBanking.Application/Transactions/Command/Create/CreateTransactionCommandHandler.cs
+++ b/RealRelianceBanking.Application/Transactions/Command/Create/CreateTransactionCommandHandler.cs
@@ -1,0 +1,89 @@
+using MediatR;
+using RealRelianceBanking.Application.Common.Interfaces.Persistance;
+using RealRelianceBanking.Application.Common.Interfaces.Services;
+using RealRelianceBanking.Domain.Entities;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace RealRelianceBanking.Application.Transactions.Command.Create
+{
+    public class CreateTransactionCommandHandler : IRequestHandler<CreateTransactionCommand, CreateTransactionResult>
+    {
+        private readonly ITransactionRepository _transactionRepository;
+        private readonly IAccountRepository _accountRepository;
+        private readonly IDateTimeProvider _dateTimeProvider;
+
+        public CreateTransactionCommandHandler(
+            ITransactionRepository transactionRepository,
+            IAccountRepository accountRepository,
+            IDateTimeProvider dateTimeProvider)
+        {
+            _transactionRepository = transactionRepository;
+            _accountRepository = accountRepository;
+            _dateTimeProvider = dateTimeProvider;
+        }
+
+        public async Task<CreateTransactionResult> Handle(CreateTransactionCommand request, CancellationToken cancellationToken)
+        {
+            if (request.Amount == 0)
+            {
+                return new CreateTransactionResult(false, "Transaction amount cannot be zero.");
+            }
+
+            if (request.TransactionDate > _dateTimeProvider.UtcNow)
+            {
+                return new CreateTransactionResult(false, "Transaction date cannot be in the future.");
+            }
+
+            if (!IsValidTransactionType(request.TransactionType))
+            {
+                return new CreateTransactionResult(false, "Transaction type must be Debit or Credit.");
+            }
+
+            var account = await _accountRepository.GetAccountById(request.AccountId);
+            if (account == null)
+            {
+                return new CreateTransactionResult(false, "Account not found.");
+            }
+
+            if (account.Status)
+            {
+                return new CreateTransactionResult(false, "Cannot add transactions to a closed account.");
+            }
+
+            var signedAmount = request.TransactionType.Equals("Debit", StringComparison.OrdinalIgnoreCase)
+                ? -Math.Abs(request.Amount)
+                : Math.Abs(request.Amount);
+
+            account.Balance += signedAmount;
+            await _accountRepository.UpdateAccountAsync(account);
+
+            var transaction = new TransactionsModel
+            {
+                TransactionId = Guid.NewGuid(),
+                AccountId = request.AccountId,
+                TransactionDate = request.TransactionDate,
+                CaptureDate = _dateTimeProvider.UtcNow,
+                Amount = signedAmount,
+                TransactionType = NormalizeTransactionType(request.TransactionType),
+                Description = request.Description
+            };
+
+            await _transactionRepository.AddTransaction(transaction);
+
+            return new CreateTransactionResult(true, "Transaction created successfully.", transaction.TransactionId);
+        }
+
+        private static bool IsValidTransactionType(string transactionType)
+        {
+            return transactionType.Equals("Debit", StringComparison.OrdinalIgnoreCase)
+                || transactionType.Equals("Credit", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static string NormalizeTransactionType(string transactionType)
+        {
+            return transactionType.Equals("Debit", StringComparison.OrdinalIgnoreCase) ? "Debit" : "Credit";
+        }
+    }
+}

--- a/RealRelianceBanking.Application/Transactions/Command/Create/CreateTransactionCommandValidator.cs
+++ b/RealRelianceBanking.Application/Transactions/Command/Create/CreateTransactionCommandValidator.cs
@@ -1,0 +1,25 @@
+using FluentValidation;
+using System;
+
+namespace RealRelianceBanking.Application.Transactions.Command.Create
+{
+    public class CreateTransactionCommandValidator : AbstractValidator<CreateTransactionCommand>
+    {
+        public CreateTransactionCommandValidator()
+        {
+            RuleFor(x => x.AccountId)
+                .NotEmpty();
+
+            RuleFor(x => x.Amount)
+                .NotEqual(0);
+
+            RuleFor(x => x.TransactionDate)
+                .LessThanOrEqualTo(DateTime.UtcNow);
+
+            RuleFor(x => x.TransactionType)
+                .Must(type => type.Equals("Debit", StringComparison.OrdinalIgnoreCase)
+                    || type.Equals("Credit", StringComparison.OrdinalIgnoreCase))
+                .WithMessage("Transaction type must be Debit or Credit.");
+        }
+    }
+}

--- a/RealRelianceBanking.Application/Transactions/Command/Create/CreateTransactionResult.cs
+++ b/RealRelianceBanking.Application/Transactions/Command/Create/CreateTransactionResult.cs
@@ -1,0 +1,6 @@
+using System;
+
+namespace RealRelianceBanking.Application.Transactions.Command.Create
+{
+    public record CreateTransactionResult(bool Success, string Message, Guid? TransactionId = null);
+}

--- a/RealRelianceBanking.Application/Transactions/Command/Transafer/TransferFundsCommand/TransferFundsCommandHandler.cs
+++ b/RealRelianceBanking.Application/Transactions/Command/Transafer/TransferFundsCommand/TransferFundsCommandHandler.cs
@@ -1,9 +1,11 @@
-﻿using MediatR;
+using MediatR;
 using RealRelianceBanking.Application.Common.Interfaces.Persistance;
+using RealRelianceBanking.Application.Common.Interfaces.Services;
 using RealRelianceBanking.Contracts.Transactions.Transafer;
 using RealRelianceBanking.Contracts.Transactions.Transafer.TransferFundsCommand;
 using RealRelianceBanking.Domain.Entities;
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Transactions;
 
@@ -14,12 +16,18 @@ namespace RealRelianceBanking.Application.Transactions.Command.Transafer
         private readonly IAccountRepository _accountRepository;
         private readonly ITransactionRepository _transactionRepository;
         private readonly IPersonRepository _personRepository;
+        private readonly IDateTimeProvider _dateTimeProvider;
 
-        public TransferFundsCommandHandler(IAccountRepository accountRepository, ITransactionRepository transactionRepository, IPersonRepository personRepository)
+        public TransferFundsCommandHandler(
+            IAccountRepository accountRepository,
+            ITransactionRepository transactionRepository,
+            IPersonRepository personRepository,
+            IDateTimeProvider dateTimeProvider)
         {
             _accountRepository = accountRepository;
             _transactionRepository = transactionRepository;
             _personRepository = personRepository;
+            _dateTimeProvider = dateTimeProvider;
         }
 
         public async Task<TransferFundsResult> Handle(TransferFundsCommand request, CancellationToken cancellationToken)
@@ -47,12 +55,12 @@ namespace RealRelianceBanking.Application.Transactions.Command.Transafer
                 return new TransferFundsResult(false, "Cannot transfer funds to the same account.");
             }
 
-            if (accountFrom.Status == true)
+            if (accountFrom.Status)
             {
                 return new TransferFundsResult(false, "Cannot transfer funds from a closed account.");
             }
 
-            if (accountTo.Status == true)
+            if (accountTo.Status)
             {
                 return new TransferFundsResult(false, "Cannot transfer funds to a closed account.");
             }
@@ -68,7 +76,7 @@ namespace RealRelianceBanking.Application.Transactions.Command.Transafer
                 return new TransferFundsResult(false, "Insufficient funds in the source account.");
             }
 
-            var currentDate = DateTime.UtcNow;
+            var currentDate = _dateTimeProvider.UtcNow;
             var outgoingDescription = BuildTransferDescription(request.description, $"Transfer to {accountTo.AccountNumber} owned by {personTo.FirstName} {personTo.LastName}");
             var incomingDescription = BuildTransferDescription(request.description, $"Transfer from {accountFrom.AccountNumber}");
 
@@ -88,6 +96,7 @@ namespace RealRelianceBanking.Application.Transactions.Command.Transafer
                     Amount = -request.Amount,
                     TransactionType = "Debit",
                     TransactionDate = currentDate,
+                    CaptureDate = currentDate,
                     Description = outgoingDescription
                 };
 
@@ -98,6 +107,7 @@ namespace RealRelianceBanking.Application.Transactions.Command.Transafer
                     Amount = request.Amount,
                     TransactionType = "Credit",
                     TransactionDate = currentDate,
+                    CaptureDate = currentDate,
                     Description = incomingDescription
                 };
 
@@ -123,6 +133,5 @@ namespace RealRelianceBanking.Application.Transactions.Command.Transafer
 
             return $"{description.Trim()} - {details}";
         }
-
     }
- }
+}

--- a/RealRelianceBanking.Application/Transactions/Command/Transafer/TransferFundsCommand/TransferFundsCommandValidator.cs
+++ b/RealRelianceBanking.Application/Transactions/Command/Transafer/TransferFundsCommand/TransferFundsCommandValidator.cs
@@ -1,0 +1,20 @@
+using FluentValidation;
+using RealRelianceBanking.Contracts.Transactions.Transafer.TransferFundsCommand;
+
+namespace RealRelianceBanking.Application.Transactions.Command.Transafer
+{
+    public class TransferFundsCommandValidator : AbstractValidator<TransferFundsCommand>
+    {
+        public TransferFundsCommandValidator()
+        {
+            RuleFor(x => x.Amount)
+                .GreaterThan(0);
+
+            RuleFor(x => x.AccountFrom)
+                .NotEmpty();
+
+            RuleFor(x => x.AccountTo)
+                .NotEmpty();
+        }
+    }
+}

--- a/RealRelianceBanking.Application/Transactions/Command/Update/UpdateTransactionCommandHandler.cs
+++ b/RealRelianceBanking.Application/Transactions/Command/Update/UpdateTransactionCommandHandler.cs
@@ -1,9 +1,8 @@
-﻿using MediatR;
+using MediatR;
 using RealRelianceBanking.Application.Common.Interfaces.Persistance;
+using RealRelianceBanking.Application.Common.Interfaces.Services;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace RealRelianceBanking.Application.Transactions.Command.Update
@@ -12,13 +11,16 @@ namespace RealRelianceBanking.Application.Transactions.Command.Update
     {
         private readonly ITransactionRepository _transactionRepository;
         private readonly IAccountRepository _accountRepository;
+        private readonly IDateTimeProvider _dateTimeProvider;
 
         public UpdateTransactionCommandHandler(
             ITransactionRepository transactionRepository,
-            IAccountRepository accountRepository)
+            IAccountRepository accountRepository,
+            IDateTimeProvider dateTimeProvider)
         {
             _transactionRepository = transactionRepository;
             _accountRepository = accountRepository;
+            _dateTimeProvider = dateTimeProvider;
         }
 
         public async Task<UpdateTransactionResult> Handle(UpdateTransactionCommand request, CancellationToken cancellationToken)
@@ -28,7 +30,7 @@ namespace RealRelianceBanking.Application.Transactions.Command.Update
                 return new UpdateTransactionResult(false, "Transaction amount cannot be zero.");
             }
 
-            if (request.TransactionDate > DateTime.UtcNow)
+            if (request.TransactionDate > _dateTimeProvider.UtcNow)
             {
                 return new UpdateTransactionResult(false, "Transaction date cannot be in the future.");
             }
@@ -45,7 +47,7 @@ namespace RealRelianceBanking.Application.Transactions.Command.Update
                 return new UpdateTransactionResult(false, "Account not found.");
             }
 
-            if (account.Status == true)
+            if (account.Status)
             {
                 return new UpdateTransactionResult(false, "Cannot update transactions for a closed account.");
             }
@@ -61,12 +63,13 @@ namespace RealRelianceBanking.Application.Transactions.Command.Update
                 existingTransaction.Description = request.Description;
                 existingTransaction.TransactionType = request.TransactionType;
                 existingTransaction.TransactionDate = request.TransactionDate;
+                existingTransaction.CaptureDate = _dateTimeProvider.UtcNow;
 
                 await _transactionRepository.UpdateTransaction(existingTransaction);
 
                 return new UpdateTransactionResult(true, "Transaction updated successfully.");
             }
-            catch (Exception ex)
+            catch (Exception)
             {
                 return new UpdateTransactionResult(false, "Failed to update transaction. Please try again later.");
             }

--- a/RealRelianceBanking.Application/Transactions/Command/Update/UpdateTransactionCommandValidator.cs
+++ b/RealRelianceBanking.Application/Transactions/Command/Update/UpdateTransactionCommandValidator.cs
@@ -1,0 +1,28 @@
+using FluentValidation;
+using System;
+
+namespace RealRelianceBanking.Application.Transactions.Command.Update
+{
+    public class UpdateTransactionCommandValidator : AbstractValidator<UpdateTransactionCommand>
+    {
+        public UpdateTransactionCommandValidator()
+        {
+            RuleFor(x => x.TransactionId)
+                .NotEmpty();
+
+            RuleFor(x => x.AccountId)
+                .NotEmpty();
+
+            RuleFor(x => x.Amount)
+                .NotEqual(0);
+
+            RuleFor(x => x.TransactionDate)
+                .LessThanOrEqualTo(DateTime.UtcNow);
+
+            RuleFor(x => x.TransactionType)
+                .Must(type => type.Equals("Debit", StringComparison.OrdinalIgnoreCase)
+                    || type.Equals("Credit", StringComparison.OrdinalIgnoreCase))
+                .WithMessage("Transaction type must be Debit or Credit.");
+        }
+    }
+}

--- a/RealRelianceBanking.Domain/Entities/Transactions.cs
+++ b/RealRelianceBanking.Domain/Entities/Transactions.cs
@@ -11,6 +11,7 @@ namespace RealRelianceBanking.Domain.Entities
         public Guid TransactionId { get; set; }
         public Guid AccountId { get; set; }
         public DateTime TransactionDate { get; set; }
+        public DateTime CaptureDate { get; set; }
         public decimal Amount { get; set; }
         public string Description { get; set; }
         public string TransactionType { get; set; }

--- a/RealRelianceBanking.Infrastructure/Persistance/PersonRepository.cs
+++ b/RealRelianceBanking.Infrastructure/Persistance/PersonRepository.cs
@@ -293,5 +293,63 @@ namespace RealRelianceBanking.Infrastructure.Persistance
                 return affectedRows > 0;
             }
         }
+
+        public async Task<List<PersonModel>> SearchPersons(int? idNumber, string? lastName, string? accountNumber)
+        {
+            using var db = _context.CreateConnection();
+
+            var sql = @"
+                SELECT
+                    p.PersonID,
+                    p.FirstName,
+                    p.LastName,
+                    p.IdNumber,
+                    p.ActiveInd,
+                    p.Email,
+                    p.PhoneNumber,
+                    p.DateOfBirth,
+
+                    a.AccountId,
+                    a.PersonID,
+                    a.AccountNumber,
+                    a.IsClosed as Status,
+                    a.ActiveInd
+                FROM Person p
+                LEFT JOIN Account a ON a.PersonID = p.PersonID
+                WHERE (@IdNumber IS NULL OR p.IdNumber = @IdNumber)
+                  AND (@LastName IS NULL OR p.LastName LIKE @LastName)
+                  AND (@AccountNumber IS NULL OR a.AccountNumber = @AccountNumber);";
+
+            var lookup = new Dictionary<Guid, PersonModel>();
+
+            await db.QueryAsync<PersonModel, Account, PersonModel>(
+                sql,
+                (person, account) =>
+                {
+                    if (!lookup.TryGetValue(person.PersonID, out var existingPerson))
+                    {
+                        existingPerson = person;
+                        existingPerson.Accounts = new List<Account>();
+                        lookup.Add(existingPerson.PersonID, existingPerson);
+                    }
+
+                    if (account != null)
+                    {
+                        existingPerson.Accounts.Add(account);
+                    }
+
+                    return existingPerson;
+                },
+                new
+                {
+                    IdNumber = idNumber,
+                    LastName = string.IsNullOrWhiteSpace(lastName) ? null : $"%{lastName.Trim()}%",
+                    AccountNumber = string.IsNullOrWhiteSpace(accountNumber) ? null : accountNumber.Trim()
+                },
+                splitOn: "AccountId"
+            );
+
+            return lookup.Values.ToList();
+        }
     }
 }

--- a/RealRelianceBanking.Infrastructure/Persistance/TransactionsRepository.cs
+++ b/RealRelianceBanking.Infrastructure/Persistance/TransactionsRepository.cs
@@ -82,8 +82,8 @@ namespace RealRelianceBanking.Infrastructure.Persistance
                 try
                 {
                     var sql = @"
-            INSERT INTO Transactions (TransactionId, AccountId, Amount, TransactionType, TransactionDate, Description, ActiveInd)
-            VALUES (@TransactionId, @AccountId, @Amount, @TransactionType, @TransactionDate, @Description, 1)";
+            INSERT INTO Transactions (TransactionId, AccountId, Amount, TransactionType, TransactionDate, CaptureDate, Description, ActiveInd)
+            VALUES (@TransactionId, @AccountId, @Amount, @TransactionType, @TransactionDate, @CaptureDate, @Description, 1)";
 
                     await db.ExecuteAsync(sql, new
                     {
@@ -92,6 +92,7 @@ namespace RealRelianceBanking.Infrastructure.Persistance
                         transaction.Amount,
                         transaction.TransactionType,
                         transaction.TransactionDate,
+                        transaction.CaptureDate,
                         transaction.Description
                     });
                 }
@@ -134,6 +135,7 @@ namespace RealRelianceBanking.Infrastructure.Persistance
                 SET Amount = @Amount,
                     TransactionType = @TransactionType,
                     TransactionDate = @TransactionDate,
+                    CaptureDate = @CaptureDate,
                     Description = @Description
                 WHERE TransactionId = @TransactionId";
 
@@ -143,6 +145,7 @@ namespace RealRelianceBanking.Infrastructure.Persistance
                 transaction.Amount,
                 transaction.TransactionType,
                 transaction.TransactionDate,
+                transaction.CaptureDate,
                 transaction.Description
             });
         }

--- a/RealRelianceBankingAPI/Controllers/Person/PersonController.cs
+++ b/RealRelianceBankingAPI/Controllers/Person/PersonController.cs
@@ -8,6 +8,7 @@ using RealRelianceBanking.Application.Person.Queries.GetPersonByEmail;
 using RealRelianceBanking.Application.Person.Queries.GetPersonById;
 using RealRelianceBanking.Application.Person.Queries.GetPersonByIdNumber;
 using RealRelianceBanking.Application.Person.Queries.GetPersons;
+using RealRelianceBanking.Application.Person.Queries.SearchPersons;
 
 namespace RealRelianceBankingAPI.Controllers.Person
 {
@@ -60,6 +61,13 @@ namespace RealRelianceBankingAPI.Controllers.Person
         {
             var person = await _mediator.Send(query);
             return Ok(person);
+        }
+
+        [HttpGet("Search")]
+        public async Task<IActionResult> SearchPersons([FromQuery] int? idNumber, [FromQuery] string? lastName, [FromQuery] string? accountNumber)
+        {
+            var results = await _mediator.Send(new SearchPersonsQuery(idNumber, lastName, accountNumber));
+            return Ok(results);
         }
 
         [HttpPut]

--- a/RealRelianceBankingAPI/Controllers/Transaction/TransactionController.cs
+++ b/RealRelianceBankingAPI/Controllers/Transaction/TransactionController.cs
@@ -7,6 +7,7 @@ using RealRelianceBanking.Contracts.Transactions.Transafer.TransferFundsCommand;
 using RealRelianceBanking.Domain.Aggregates;
 using Microsoft.AspNetCore.Authorization;
 using RealRelianceBanking.Application.Transactions.Command.Update;
+using RealRelianceBanking.Application.Transactions.Command.Create;
 
 namespace RealRelianceBankingAPI.Controllers.Transaction
 {
@@ -39,6 +40,18 @@ namespace RealRelianceBankingAPI.Controllers.Transaction
                 return Ok(result);
             }
             return BadRequest(result);
+        }
+
+        [HttpPost("Create")]
+        public async Task<IActionResult> CreateTransaction([FromBody] CreateTransactionCommand command)
+        {
+            var result = await _mediator.Send(command);
+            if (result.Success)
+            {
+                return Ok(result);
+            }
+
+            return BadRequest(result.Message);
         }
 
         [HttpGet("GetTransactions")]

--- a/Tests/Commands/TransatioinsTests/CreateTransactionCommandHandlerTests.cs
+++ b/Tests/Commands/TransatioinsTests/CreateTransactionCommandHandlerTests.cs
@@ -1,0 +1,62 @@
+using Moq;
+using RealRelianceBanking.Application.Common.Interfaces.Persistance;
+using RealRelianceBanking.Application.Common.Interfaces.Services;
+using RealRelianceBanking.Application.Transactions.Command.Create;
+using RealRelianceBanking.Domain.Entities;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Tests.Commands.TransatioinsTests
+{
+    public class CreateTransactionCommandHandlerTests
+    {
+        private readonly Mock<ITransactionRepository> _transactionRepository;
+        private readonly Mock<IAccountRepository> _accountRepository;
+        private readonly Mock<IDateTimeProvider> _dateTimeProvider;
+        private readonly CreateTransactionCommandHandler _handler;
+
+        public CreateTransactionCommandHandlerTests()
+        {
+            _transactionRepository = new Mock<ITransactionRepository>();
+            _accountRepository = new Mock<IAccountRepository>();
+            _dateTimeProvider = new Mock<IDateTimeProvider>();
+            _dateTimeProvider.Setup(provider => provider.UtcNow).Returns(DateTime.UtcNow);
+
+            _handler = new CreateTransactionCommandHandler(
+                _transactionRepository.Object,
+                _accountRepository.Object,
+                _dateTimeProvider.Object);
+        }
+
+        [Fact]
+        public async Task Handle_ValidCreditTransaction_UpdatesBalance()
+        {
+            var accountId = Guid.NewGuid();
+            var account = new Account
+            {
+                AccountID = accountId,
+                Balance = 100m,
+                Status = false
+            };
+
+            _accountRepository.Setup(repo => repo.GetAccountById(accountId))
+                .ReturnsAsync(account);
+
+            var command = new CreateTransactionCommand(
+                accountId,
+                DateTime.UtcNow.Date,
+                50m,
+                "Credit",
+                "Deposit");
+
+            var result = await _handler.Handle(command, CancellationToken.None);
+
+            Assert.True(result.Success);
+            Assert.Equal(150m, account.Balance);
+            _transactionRepository.Verify(repo => repo.AddTransaction(It.IsAny<TransactionsModel>()), Times.Once);
+            _accountRepository.Verify(repo => repo.UpdateAccountAsync(account), Times.Once);
+        }
+    }
+}

--- a/Tests/Commands/TransatioinsTests/TransferCommandHandlerTests.cs
+++ b/Tests/Commands/TransatioinsTests/TransferCommandHandlerTests.cs
@@ -7,6 +7,7 @@ using Xunit;
 using RealRelianceBanking.Contracts.Transactions.Transafer.TransferFundsCommand;
 using RealRelianceBanking.Application.Transactions.Command.Transafer;
 using RealRelianceBanking.Domain.Aggregates;
+using RealRelianceBanking.Application.Common.Interfaces.Services;
 namespace Tests.Commands.TransatioinsTests
 {
     public class TransferCommandHandlerTests
@@ -14,6 +15,7 @@ namespace Tests.Commands.TransatioinsTests
         private readonly Mock<IAccountRepository> _mockAccountRepository;
         private readonly Mock<ITransactionRepository> _mockTransactionRepository;
         private readonly Mock<IPersonRepository> _mockPersonRepository;
+        private readonly Mock<IDateTimeProvider> _mockDateTimeProvider;
         private readonly TransferFundsCommandHandler _handler;
 
         public TransferCommandHandlerTests()
@@ -21,7 +23,13 @@ namespace Tests.Commands.TransatioinsTests
             _mockAccountRepository = new Mock<IAccountRepository>();
             _mockTransactionRepository = new Mock<ITransactionRepository>();
             _mockPersonRepository = new Mock<IPersonRepository>();
-            _handler = new TransferFundsCommandHandler(_mockAccountRepository.Object, _mockTransactionRepository.Object, _mockPersonRepository.Object);
+            _mockDateTimeProvider = new Mock<IDateTimeProvider>();
+            _mockDateTimeProvider.Setup(provider => provider.UtcNow).Returns(DateTime.UtcNow);
+            _handler = new TransferFundsCommandHandler(
+                _mockAccountRepository.Object,
+                _mockTransactionRepository.Object,
+                _mockPersonRepository.Object,
+                _mockDateTimeProvider.Object);
         }
 
         [Fact]

--- a/command-prompts.txt
+++ b/command-prompts.txt
@@ -1,0 +1,45 @@
+## Baseline inventory (architecture + endpoints)
+find RealRelianceBankingAPI RealRelianceBanking.Application RealRelianceBanking.Infrastructure RealRelianceBanking.Domain -type f
+find RealRelianceBankingAPI/Controllers -type f
+rg -n "" RealRelianceBankingAPI/Program.cs
+
+## Persons requirements (unique ID, delete rules, searches)
+rg -n "" RealRelianceBanking.Application/Person/Command/CreatePerson/CreatePersonCommandHandler.cs
+rg -n "" RealRelianceBanking.Application/Person/Command/DeletePerson/DeletePersonCommandHandler.cs
+rg -n "" RealRelianceBanking.Application/Person/Command/EditPerson/EditPersonCommandHandler.cs
+rg -n "IdNumber|Email|LastName|Surname|AccountNumber" RealRelianceBanking.Application/Person RealRelianceBanking.Infrastructure/Persistance
+
+## Accounts requirements (duplicate numbers, balance rules, close rules)
+rg -n "" RealRelianceBanking.Application/Accounts/Commands/AddAccount/AddAccountCommandHandler.cs
+rg -n "" RealRelianceBanking.Application/Accounts/Commands/CloseAccountCommand/CloseAccountCommandHandler.cs
+rg -n "" RealRelianceBanking.Infrastructure/Persistance/AccountsRepository.cs
+
+## Transactions requirements (date, amount, closed account, balance updates)
+rg -n "" RealRelianceBanking.Application/Transactions/Command/Update/UpdateTransactionCommandHandler.cs
+rg -n "" RealRelianceBanking.Application/Transactions/Command/Transafer/TransferFundsCommand/TransferFundsCommandHandler.cs
+rg -n "" RealRelianceBanking.Domain/Entities/Transactions.cs
+rg -n "" InteractiveMVC_Tables_With_Data.sql
+
+## Validation framework checks
+rg -n "Validator|Validation|FluentValidation" RealRelianceBanking.Application
+
+## Endpoint coverage checks
+rg -n "" RealRelianceBankingAPI/Controllers/Person/PersonController.cs
+rg -n "" RealRelianceBankingAPI/Controllers/Account/AccountController.cs
+rg -n "" RealRelianceBankingAPI/Controllers/Transaction/TransactionController.cs
+
+## Unit test coverage checks
+find Tests -type f
+rg -n "" Tests/Commands/AccountTests/CreateAccountCommandHandler.cs
+rg -n "" Tests/Commands/TransatioinsTests/TransferCommandHandlerTests.cs
+rg -n "" Tests/Commands/PersonTests/DeletePersonCommandHandlerTest.cs
+
+## Optional: full solution build and test run
+dotnet build RealRelianceBankingAPI/RealRelianceBankingAPI.sln
+dotnet test Tests/Tests.csproj
+
+## Gap-closing implementation prompts (run later as instruction prompts)
+Implement surname + account number search per assessment; keep Clean Architecture + Dapper repo patterns. Add query + handler in Application, update repository in Infrastructure, expose in Person/Account controllers.
+Add transaction capture date field: update SQL schema, entity model, repository inserts/updates, and handler rules. Ensure capture date auto-updates on create/edit and is not user-editable.
+Add validation layer (FluentValidation or equivalent) for all commands: Persons, Accounts, Transactions must enforce data types and business rules.
+Add "AddTransaction" endpoint and handler for single-account debit/credit (non-transfer). Ensure balance updates and closed-account rules are enforced.


### PR DESCRIPTION
### Motivation
- Close gaps identified in the assessment by adding person search (id/last name/account), single-account transaction support, and transaction capture-date tracking.
- Enforce command-level validation to surface input errors early and centralize validation rules.
- Keep clean-architecture patterns (Application/Infrastructure/API) and update repositories/controllers to expose the new functionality.

### Description
- Added `CaptureDate` to the `TransactionsModel`, updated `InteractiveMVC_Tables_With_Data.sql`, and changed `TransactionsRepository` to persist `CaptureDate` on insert/update.
- Implemented `CreateTransaction` command/handler/result/validator and a `POST api/Transaction/Create` endpoint that updates account balance, prevents transactions on closed accounts, and sets `CaptureDate` using an `IDateTimeProvider`.
- Enhanced transfer flow to use `IDateTimeProvider` and set `CaptureDate` for transfer transactions, and updated the transfer handler and tests accordingly.
- Added FluentValidation support and a MediatR pipeline `ValidationBehavior`, registered validators in `DependencyInjection`, and added validators for person create/edit, account create, transaction create/update, and transfer commands; also updated the csproj with FluentValidation package references.
- Added person search support: `IPersonRepository.SearchPersons(...)`, repository Dapper query that joins accounts, an Application `SearchPersonsQuery`/handler, and `GET api/Persons/Search` controller endpoint.
- Added/updated unit tests: `CreateTransactionCommandHandlerTests` (new) and updated `TransferCommandHandlerTests` to inject `IDateTimeProvider`, and included a new `command-prompts.txt` for quick checks.

### Testing
- Added unit tests under `Tests/Commands/TransatioinsTests` for `CreateTransactionCommandHandler` and updated transfer tests, but no test runner was available in the environment; `dotnet test Tests/Tests.csproj` was attempted and failed because `dotnet` is not available in this environment (execution error: `bash: command not found: dotnet`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b20d071248330891f201f5c380fdf)