### PR TITLE
Update command handler tests to match current delete-person and transfer behavior

### DIFF
--- a/Tests/Commands/PersonTests/DeletePersonCommandHandlerTest.cs
+++ b/Tests/Commands/PersonTests/DeletePersonCommandHandlerTest.cs
@@ -1,9 +1,5 @@
-﻿using MediatR;
-using RealRelianceBanking.Application.Person.Command.DeletePerson;
+﻿using RealRelianceBanking.Application.Person.Command.DeletePerson;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace Tests.Commands.PersonTests
@@ -11,66 +7,105 @@ namespace Tests.Commands.PersonTests
     public class DeletePersonCommandHandlerTests
     {
         private readonly Mock<IPersonRepository> _mockPersonRepository;
+        private readonly Mock<IAccountRepository> _mockAccountRepository;
         private readonly DeletePersonCommandHandler _handler;
 
         public DeletePersonCommandHandlerTests()
         {
             _mockPersonRepository = new Mock<IPersonRepository>();
-            _handler = new DeletePersonCommandHandler(_mockPersonRepository.Object);
+            _mockAccountRepository = new Mock<IAccountRepository>();
+            _handler = new DeletePersonCommandHandler(
+                _mockPersonRepository.Object,
+                _mockAccountRepository.Object);
         }
 
         [Fact]
         public async Task Handle_PersonWithNoActiveAccounts_ShouldDeactivatePerson()
         {
             // Arrange
-            var command = new DeletePersonCommand(Guid.NewGuid());
-            _mockPersonRepository.Setup(repo => repo.HasActiveAccounts(command.PersonId))
+            const int idNumber = 123456;
+            var command = new DeletePersonCommand(idNumber);
+            var person = new PersonModel
+            {
+                PersonID = Guid.NewGuid(),
+                IdNumber = idNumber
+            };
+
+            _mockPersonRepository.Setup(repo => repo.GetByIdNumberAsync(idNumber))
+                .ReturnsAsync(person);
+            _mockAccountRepository.Setup(repo => repo.HasActiveAccounts(person.PersonID))
                 .ReturnsAsync(false);
 
             // Act
             var result = await _handler.Handle(command, CancellationToken.None);
 
             // Assert
-            _mockPersonRepository.Verify(repo => repo.Deactivate(command.PersonId), Times.Once);
-            Assert.Equal(Unit.Value, result);
+            _mockPersonRepository.Verify(repo => repo.Deactivate(person.PersonID), Times.Once);
+            Assert.True(result.Success);
+            Assert.Equal("Person deleted successfully.", result.Message);
         }
 
         [Fact]
-        public async Task Handle_PersonWithActiveAccounts_ShouldThrowApplicationException()
+        public async Task Handle_PersonWithActiveAccounts_ShouldReturnFailureResult()
         {
             // Arrange
-            var command = new DeletePersonCommand(Guid.NewGuid());
-            _mockPersonRepository.Setup(repo => repo.HasActiveAccounts(command.PersonId))
+            const int idNumber = 654321;
+            var command = new DeletePersonCommand(idNumber);
+            var person = new PersonModel
+            {
+                PersonID = Guid.NewGuid(),
+                IdNumber = idNumber
+            };
+
+            _mockPersonRepository.Setup(repo => repo.GetByIdNumberAsync(idNumber))
+                .ReturnsAsync(person);
+            _mockAccountRepository.Setup(repo => repo.HasActiveAccounts(person.PersonID))
                 .ReturnsAsync(true);
 
             // Act & Assert
-            await Assert.ThrowsAsync<ApplicationException>(() =>
-                _handler.Handle(command, CancellationToken.None));
+            var result = await _handler.Handle(command, CancellationToken.None);
+
+            Assert.False(result.Success);
+            Assert.Equal("Cannot delete person with active accounts. Close all accounts first.", result.Message);
             _mockPersonRepository.Verify(repo => repo.Deactivate(It.IsAny<Guid>()), Times.Never);
         }
 
         [Fact]
-        public async Task Handle_RepositoryThrowsException_ShouldPropagateException()
+        public async Task Handle_PersonNotFound_ShouldReturnFailureResult()
         {
             // Arrange
-            var command = new DeletePersonCommand(Guid.NewGuid());
-            _mockPersonRepository.Setup(repo => repo.HasActiveAccounts(command.PersonId))
-                .ThrowsAsync(new Exception("Database error"));
+            const int idNumber = 999999;
+            var command = new DeletePersonCommand(idNumber);
 
-            // Act & Assert
-            await Assert.ThrowsAsync<Exception>(() =>
-                _handler.Handle(command, CancellationToken.None));
+            _mockPersonRepository.Setup(repo => repo.GetByIdNumberAsync(idNumber))
+                .ReturnsAsync((PersonModel)null);
+
+            // Act
+            var result = await _handler.Handle(command, CancellationToken.None);
+
+            // Assert
+            Assert.False(result.Success);
+            Assert.Equal("Person not found.", result.Message);
+            _mockAccountRepository.Verify(repo => repo.HasActiveAccounts(It.IsAny<Guid>()), Times.Never);
+            _mockPersonRepository.Verify(repo => repo.Deactivate(It.IsAny<Guid>()), Times.Never);
         }
 
         [Fact]
-        public async Task Handle_DeactivateThrowsException_ShouldPropagateException()
+        public async Task Handle_AccountRepositoryThrowsException_ShouldPropagateException()
         {
             // Arrange
-            var command = new DeletePersonCommand(Guid.NewGuid());
-            _mockPersonRepository.Setup(repo => repo.HasActiveAccounts(command.PersonId))
-                .ReturnsAsync(false);
-            _mockPersonRepository.Setup(repo => repo.Deactivate(command.PersonId))
-                .ThrowsAsync(new Exception("Deactivation failed"));
+            const int idNumber = 123987;
+            var command = new DeletePersonCommand(idNumber);
+            var person = new PersonModel
+            {
+                PersonID = Guid.NewGuid(),
+                IdNumber = idNumber
+            };
+
+            _mockPersonRepository.Setup(repo => repo.GetByIdNumberAsync(idNumber))
+                .ReturnsAsync(person);
+            _mockAccountRepository.Setup(repo => repo.HasActiveAccounts(person.PersonID))
+                .ThrowsAsync(new Exception("Database error"));
 
             // Act & Assert
             await Assert.ThrowsAsync<Exception>(() =>

--- a/Tests/Commands/TransatioinsTests/TransferCommandHandlerTests.cs
+++ b/Tests/Commands/TransatioinsTests/TransferCommandHandlerTests.cs
@@ -1,13 +1,12 @@
 using System;
-using System.Security.Principal;
 using System.Threading;
 using System.Threading.Tasks;
 using Moq;
 using Xunit;
 using RealRelianceBanking.Contracts.Transactions.Transafer.TransferFundsCommand;
 using RealRelianceBanking.Application.Transactions.Command.Transafer;
-using RealRelianceBanking.Domain.Aggregates;
 using RealRelianceBanking.Application.Common.Interfaces.Services;
+using RealRelianceBanking.Domain.Entities;
 namespace Tests.Commands.TransatioinsTests
 {
     public class TransferCommandHandlerTests


### PR DESCRIPTION
### Motivation
- Align unit tests with recent handler API changes for delete-person and transfer flows so tests reflect actual handler contracts and messages.
- Remove stale imports and adjust mocks to match updated dependencies used by the handlers.

### Description
- Updated `Tests/Commands/PersonTests/DeletePersonCommandHandlerTest.cs` to use integer `IdNumber` inputs, add a `Mock<IAccountRepository>`, call `GetByIdNumberAsync`, and assert on the `DeletePersonResult` payload instead of expecting exceptions or `Unit` values.
- Added tests for person-not-found and account-repository failure scenarios, and adjusted existing active-account and exception propagation tests to the handler's current behavior and messages.
- Cleaned up `Tests/Commands/TransatioinsTests/TransferCommandHandlerTests.cs` imports to use the domain `Account`/`PersonModel` entities and removed an unused `using`.
- Committed changes that update two test files: `Tests/Commands/PersonTests/DeletePersonCommandHandlerTest.cs` and `Tests/Commands/TransatioinsTests/TransferCommandHandlerTests.cs`.

### Testing
- Could not run automated tests because `dotnet` was not available in the environment, so `dotnet test` was not executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b378255ac83309fafde9f6e63cb33)