### PR TITLE
Add account query and person command handler tests; expand CreateTransaction tests

### DIFF
--- a/Tests/Commands/PersonTests/CreatePersonCommandHandlerTests.cs
+++ b/Tests/Commands/PersonTests/CreatePersonCommandHandlerTests.cs
@@ -1,0 +1,68 @@
+using RealRelianceBanking.Application.Person.Command.CreatePerson;
+
+namespace Tests.Commands.PersonTests
+{
+    public class CreatePersonCommandHandlerTests
+    {
+        private readonly Mock<IPersonRepository> _personRepository;
+        private readonly CreatePersonCommandHandler _handler;
+
+        public CreatePersonCommandHandlerTests()
+        {
+            _personRepository = new Mock<IPersonRepository>();
+            _handler = new CreatePersonCommandHandler(_personRepository.Object);
+        }
+
+        [Fact]
+        public async Task Handle_NewPerson_ReturnsSuccessResponse()
+        {
+            var command = new CreatePersonCommand(
+                123456,
+                "Jamie",
+                "Reed",
+                "jamie@example.com",
+                "555-0101",
+                new DateTime(1990, 1, 1));
+
+            _personRepository.Setup(repo => repo.GetByIdNumberAsync(command.IdNumber))
+                .ReturnsAsync((PersonModel)null);
+            _personRepository.Setup(repo => repo.Add(It.IsAny<PersonModel>()))
+                .ReturnsAsync(Guid.NewGuid());
+
+            var result = await _handler.Handle(command, CancellationToken.None);
+
+            Assert.True(result.Success);
+            Assert.NotEqual(Guid.Empty, result.PersonId);
+            Assert.Null(result.ErrorMessage);
+            _personRepository.Verify(repo => repo.Add(It.Is<PersonModel>(p =>
+                p.IdNumber == command.IdNumber &&
+                p.FirstName == command.FirstName &&
+                p.LastName == command.LastName &&
+                p.Email == command.Email &&
+                p.PhoneNumber == command.PhoneNumber &&
+                p.DateOfBirth == command.DateOfBirth &&
+                p.ActiveInd)), Times.Once);
+        }
+
+        [Fact]
+        public async Task Handle_DuplicateIdNumber_ReturnsFailureResponse()
+        {
+            var command = new CreatePersonCommand(
+                999999,
+                "Alex",
+                "Stone",
+                "alex@example.com",
+                "555-0199",
+                new DateTime(1985, 12, 10));
+
+            _personRepository.Setup(repo => repo.GetByIdNumberAsync(command.IdNumber))
+                .ReturnsAsync(new PersonModel { IdNumber = command.IdNumber });
+
+            var result = await _handler.Handle(command, CancellationToken.None);
+
+            Assert.False(result.Success);
+            Assert.Equal($"A person with ID Number {command.IdNumber} already exists.", result.ErrorMessage);
+            _personRepository.Verify(repo => repo.Add(It.IsAny<PersonModel>()), Times.Never);
+        }
+    }
+}

--- a/Tests/Commands/TransatioinsTests/CreateTransactionCommandHandlerTests.cs
+++ b/Tests/Commands/TransatioinsTests/CreateTransactionCommandHandlerTests.cs
@@ -58,5 +58,139 @@ namespace Tests.Commands.TransatioinsTests
             _transactionRepository.Verify(repo => repo.AddTransaction(It.IsAny<TransactionsModel>()), Times.Once);
             _accountRepository.Verify(repo => repo.UpdateAccountAsync(account), Times.Once);
         }
+
+        [Fact]
+        public async Task Handle_ValidDebitTransaction_DeductsBalance()
+        {
+            var accountId = Guid.NewGuid();
+            var account = new Account
+            {
+                AccountID = accountId,
+                Balance = 200m,
+                Status = false
+            };
+
+            _accountRepository.Setup(repo => repo.GetAccountById(accountId))
+                .ReturnsAsync(account);
+
+            var command = new CreateTransactionCommand(
+                accountId,
+                DateTime.UtcNow.Date,
+                75m,
+                "Debit",
+                "Withdrawal");
+
+            var result = await _handler.Handle(command, CancellationToken.None);
+
+            Assert.True(result.Success);
+            Assert.Equal(125m, account.Balance);
+            _transactionRepository.Verify(repo => repo.AddTransaction(It.Is<TransactionsModel>(t => t.Amount == -75m && t.TransactionType == "Debit")), Times.Once);
+            _accountRepository.Verify(repo => repo.UpdateAccountAsync(account), Times.Once);
+        }
+
+        [Fact]
+        public async Task Handle_ZeroAmount_ReturnsFailureResult()
+        {
+            var command = new CreateTransactionCommand(
+                Guid.NewGuid(),
+                DateTime.UtcNow.Date,
+                0m,
+                "Credit",
+                "Zero amount");
+
+            var result = await _handler.Handle(command, CancellationToken.None);
+
+            Assert.False(result.Success);
+            Assert.Equal("Transaction amount cannot be zero.", result.Message);
+            _accountRepository.Verify(repo => repo.GetAccountById(It.IsAny<Guid>()), Times.Never);
+            _transactionRepository.Verify(repo => repo.AddTransaction(It.IsAny<TransactionsModel>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task Handle_FutureTransactionDate_ReturnsFailureResult()
+        {
+            var command = new CreateTransactionCommand(
+                Guid.NewGuid(),
+                DateTime.UtcNow.AddDays(1),
+                25m,
+                "Credit",
+                "Future date");
+
+            var result = await _handler.Handle(command, CancellationToken.None);
+
+            Assert.False(result.Success);
+            Assert.Equal("Transaction date cannot be in the future.", result.Message);
+            _accountRepository.Verify(repo => repo.GetAccountById(It.IsAny<Guid>()), Times.Never);
+            _transactionRepository.Verify(repo => repo.AddTransaction(It.IsAny<TransactionsModel>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task Handle_InvalidTransactionType_ReturnsFailureResult()
+        {
+            var command = new CreateTransactionCommand(
+                Guid.NewGuid(),
+                DateTime.UtcNow.Date,
+                25m,
+                "Refund",
+                "Invalid type");
+
+            var result = await _handler.Handle(command, CancellationToken.None);
+
+            Assert.False(result.Success);
+            Assert.Equal("Transaction type must be Debit or Credit.", result.Message);
+            _accountRepository.Verify(repo => repo.GetAccountById(It.IsAny<Guid>()), Times.Never);
+            _transactionRepository.Verify(repo => repo.AddTransaction(It.IsAny<TransactionsModel>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task Handle_AccountNotFound_ReturnsFailureResult()
+        {
+            var accountId = Guid.NewGuid();
+            var command = new CreateTransactionCommand(
+                accountId,
+                DateTime.UtcNow.Date,
+                40m,
+                "Credit",
+                "Missing account");
+
+            _accountRepository.Setup(repo => repo.GetAccountById(accountId))
+                .ReturnsAsync((Account)null);
+
+            var result = await _handler.Handle(command, CancellationToken.None);
+
+            Assert.False(result.Success);
+            Assert.Equal("Account not found.", result.Message);
+            _accountRepository.Verify(repo => repo.UpdateAccountAsync(It.IsAny<Account>()), Times.Never);
+            _transactionRepository.Verify(repo => repo.AddTransaction(It.IsAny<TransactionsModel>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task Handle_ClosedAccount_ReturnsFailureResult()
+        {
+            var accountId = Guid.NewGuid();
+            var account = new Account
+            {
+                AccountID = accountId,
+                Balance = 100m,
+                Status = true
+            };
+
+            _accountRepository.Setup(repo => repo.GetAccountById(accountId))
+                .ReturnsAsync(account);
+
+            var command = new CreateTransactionCommand(
+                accountId,
+                DateTime.UtcNow.Date,
+                20m,
+                "Credit",
+                "Closed account");
+
+            var result = await _handler.Handle(command, CancellationToken.None);
+
+            Assert.False(result.Success);
+            Assert.Equal("Cannot add transactions to a closed account.", result.Message);
+            _accountRepository.Verify(repo => repo.UpdateAccountAsync(It.IsAny<Account>()), Times.Never);
+            _transactionRepository.Verify(repo => repo.AddTransaction(It.IsAny<TransactionsModel>()), Times.Never);
+        }
     }
 }

--- a/Tests/Query/AccountTests/GetAccountByIdQueryHandlerTests.cs
+++ b/Tests/Query/AccountTests/GetAccountByIdQueryHandlerTests.cs
@@ -1,0 +1,50 @@
+using RealRelianceBanking.Application.Accounts.Queries.GetAccountById;
+
+namespace Tests.Query.AccountTests
+{
+    public class GetAccountByIdQueryHandlerTests
+    {
+        private readonly Mock<IAccountRepository> _accountRepository;
+        private readonly GetAccountByIdQueryHandler _handler;
+
+        public GetAccountByIdQueryHandlerTests()
+        {
+            _accountRepository = new Mock<IAccountRepository>();
+            _handler = new GetAccountByIdQueryHandler(_accountRepository.Object);
+        }
+
+        [Fact]
+        public async Task Handle_ExistingAccount_ReturnsAccount()
+        {
+            var accountId = Guid.NewGuid();
+            var account = new Account
+            {
+                AccountID = accountId,
+                AccountNumber = "555000",
+                Balance = 250m
+            };
+
+            _accountRepository.Setup(repo => repo.GetAccountById(accountId))
+                .ReturnsAsync(account);
+
+            var result = await _handler.Handle(new GetAccountByIdQuery(accountId), CancellationToken.None);
+
+            Assert.Equal(account, result);
+            _accountRepository.Verify(repo => repo.GetAccountById(accountId), Times.Once);
+        }
+
+        [Fact]
+        public async Task Handle_MissingAccount_ReturnsNull()
+        {
+            var accountId = Guid.NewGuid();
+
+            _accountRepository.Setup(repo => repo.GetAccountById(accountId))
+                .ReturnsAsync((Account)null);
+
+            var result = await _handler.Handle(new GetAccountByIdQuery(accountId), CancellationToken.None);
+
+            Assert.Null(result);
+            _accountRepository.Verify(repo => repo.GetAccountById(accountId), Times.Once);
+        }
+    }
+}

--- a/Tests/Query/AccountTests/GetAccountsQueryHandlerTests.cs
+++ b/Tests/Query/AccountTests/GetAccountsQueryHandlerTests.cs
@@ -1,0 +1,64 @@
+using RealRelianceBanking.Application.Accounts.Queries.GetAccount;
+using RealRelianceBanking.Application.Accounts.Queries.GetAccounts;
+using RealRelianceBanking.Domain.Aggregates;
+
+namespace Tests.Query.AccountTests
+{
+    public class GetAccountsQueryHandlerTests
+    {
+        private readonly Mock<IAccountRepository> _accountRepository;
+        private readonly GetAccountsQueryHandler _handler;
+
+        public GetAccountsQueryHandlerTests()
+        {
+            _accountRepository = new Mock<IAccountRepository>();
+            _handler = new GetAccountsQueryHandler(_accountRepository.Object);
+        }
+
+        [Fact]
+        public async Task Handle_ActiveOnlyQuery_ReturnsAccounts()
+        {
+            var accounts = new List<AccountAggregate>
+            {
+                new AccountAggregate
+                {
+                    AccountNumber = "100200",
+                    AccountType = "Savings",
+                    Balance = 25m,
+                    ActiveInd = true
+                }
+            };
+
+            _accountRepository.Setup(repo => repo.GetAccounts(true))
+                .ReturnsAsync(accounts);
+
+            var result = await _handler.Handle(new GetAccountsQuery(true), CancellationToken.None);
+
+            Assert.Equal(accounts, result);
+            _accountRepository.Verify(repo => repo.GetAccounts(true), Times.Once);
+        }
+
+        [Fact]
+        public async Task Handle_AllAccountsQuery_ReturnsAccounts()
+        {
+            var accounts = new List<AccountAggregate>
+            {
+                new AccountAggregate
+                {
+                    AccountNumber = "100201",
+                    AccountType = "Checking",
+                    Balance = 120m,
+                    ActiveInd = false
+                }
+            };
+
+            _accountRepository.Setup(repo => repo.GetAccounts(false))
+                .ReturnsAsync(accounts);
+
+            var result = await _handler.Handle(new GetAccountsQuery(false), CancellationToken.None);
+
+            Assert.Equal(accounts, result);
+            _accountRepository.Verify(repo => repo.GetAccounts(false), Times.Once);
+        }
+    }
+}


### PR DESCRIPTION
### Motivation

- Improve unit test coverage for account query handlers, person creation, and the create-transaction flow to validate success and failure branches.
- Ensure repository interactions and business-rule validation in `CreateTransactionCommandHandler` and `CreatePersonCommandHandler` are exercised.

### Description

- Added `Tests/Commands/PersonTests/CreatePersonCommandHandlerTests.cs` with success and duplicate-ID scenarios that verify `IPersonRepository.GetByIdNumberAsync` and `IPersonRepository.Add` behavior.
- Added `Tests/Query/AccountTests/GetAccountByIdQueryHandlerTests.cs` to cover existing and missing account lookups via `GetAccountByIdQueryHandler`.
- Added `Tests/Query/AccountTests/GetAccountsQueryHandlerTests.cs` to cover active-only and all-accounts queries via `GetAccountsQueryHandler`.
- Expanded `Tests/Commands/TransatioinsTests/CreateTransactionCommandHandlerTests.cs` with additional cases for valid debit processing and validation failures (zero amount, future date, invalid type, account not found, closed account) and added assertions verifying `IAccountRepository` and `ITransactionRepository` calls.

### Testing

- No automated tests were executed in this change; run `dotnet test` locally or in CI to validate the new tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b3bf88cf08330b709d8e51e9d0394)