### PR TITLE
Enhance CI workflow: run on all branches, add concurrency and .NET caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,21 +1,34 @@
-name: ci
+name: CI
 
 on:
   pull_request:
   push:
     branches:
-      - main
-      - master
+      - "**"
+  workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build-test:
     runs-on: ubuntu-latest
+    env:
+      DOTNET_NOLOGO: true
+      DOTNET_CLI_TELEMETRY_OPTOUT: 1
     steps:
       - uses: actions/checkout@v4
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: "7.0.x"
+          cache: true
+          cache-dependency-path: |
+            **/*.csproj
+            **/*.fsproj
+            **/*.vbproj
+            **/packages.lock.json
       - name: Restore
         run: dotnet restore RealRelianceBankingAPI/RealRelianceBankingAPI.sln
       - name: Build


### PR DESCRIPTION
### Motivation
- Make the repository CI more robust and developer-friendly by running checks for broader events and improving .NET build consistency and speed.
- Prevent duplicate concurrent runs for the same ref to save resources and avoid wasted work.

### Description
- Expanded `.github/workflows/ci.yml` to trigger on all pushes (`branches: "**"`) and added `workflow_dispatch` for manual runs.
- Added `concurrency` with `group: ci-${{ github.ref }}` and `cancel-in-progress: true` to avoid duplicate runs for the same ref.
- Set standard .NET environment flags (`DOTNET_NOLOGO`, `DOTNET_CLI_TELEMETRY_OPTOUT`) and enabled `actions/setup-dotnet` caching with a `cache-dependency-path` for project files and `packages.lock.json` to speed up CI builds.
- Kept existing pipeline steps that run `dotnet restore`, `dotnet build --configuration Release --no-restore`, and `dotnet test --configuration Release --no-build` against the solution at `RealRelianceBankingAPI/RealRelianceBankingAPI.sln`.

### Testing
- No automated tests were executed locally because this is a CI configuration change only.
- The workflow is configured to run the existing automated steps `dotnet restore`, `dotnet build`, and `dotnet test` on GitHub Actions for pushed branches and pull requests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b4f08e4cc83308f5d5efdf4f8669d)