### PR TITLE
Add API versioning and versioned Swagger support

### DIFF
--- a/RealRelianceBankingAPI/Common/ConfigureSwaggerOptions.cs
+++ b/RealRelianceBankingAPI/Common/ConfigureSwaggerOptions.cs
@@ -1,0 +1,28 @@
+using Asp.Versioning.ApiExplorer;
+using Microsoft.Extensions.Options;
+using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.SwaggerGen;
+
+namespace RealRelianceBankingAPI.Common;
+
+public sealed class ConfigureSwaggerOptions : IConfigureOptions<SwaggerGenOptions>
+{
+    private readonly IApiVersionDescriptionProvider _provider;
+
+    public ConfigureSwaggerOptions(IApiVersionDescriptionProvider provider)
+    {
+        _provider = provider;
+    }
+
+    public void Configure(SwaggerGenOptions options)
+    {
+        foreach (var description in _provider.ApiVersionDescriptions)
+        {
+            options.SwaggerDoc(description.GroupName, new OpenApiInfo
+            {
+                Title = "RealReliance Bank API",
+                Version = description.ApiVersion.ToString()
+            });
+        }
+    }
+}

--- a/RealRelianceBankingAPI/Controllers/Account/AccountController.cs
+++ b/RealRelianceBankingAPI/Controllers/Account/AccountController.cs
@@ -1,4 +1,5 @@
-﻿using MediatR;
+﻿using Asp.Versioning;
+using MediatR;
 using Microsoft.AspNetCore.Mvc;
 using RealRelianceBanking.Application.Transactions.Queries.GetAccountTransactions;
 using RealRelianceBanking.Application.Accounts.Queries.GetAccountById;
@@ -13,7 +14,8 @@ using Microsoft.AspNetCore.Authentication.JwtBearer;
 namespace RealRelianceBankingAPI.Controllers.Account
 {
 
-    [Route("api/[controller]")]
+    [ApiVersion("1.0")]
+    [Route("api/v{version:apiVersion}/[controller]")]
     [ApiController]
     [Authorize]
     public class AccountsController : ControllerBase

--- a/RealRelianceBankingAPI/Controllers/Authentication/AuthenticationController.cs
+++ b/RealRelianceBankingAPI/Controllers/Authentication/AuthenticationController.cs
@@ -1,4 +1,5 @@
-﻿using MediatR;
+﻿using Asp.Versioning;
+using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using RealRelianceBanking.Application.Authentication.Commands.RefreshToken;
@@ -8,7 +9,8 @@ using RealRelianceBanking.Application.Common.Errors;
 
 namespace RealRelianceBankingAPI.Controllers.Authentication
 {
-    [Route("api/[controller]")]
+    [ApiVersion("1.0")]
+    [Route("api/v{version:apiVersion}/[controller]")]
     [ApiController]
     [AllowAnonymous]
     public class AuthenticationController : ControllerBase

--- a/RealRelianceBankingAPI/Controllers/Contact/ContactController.cs
+++ b/RealRelianceBankingAPI/Controllers/Contact/ContactController.cs
@@ -1,4 +1,5 @@
-﻿using MediatR;
+﻿using Asp.Versioning;
+using MediatR;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
 using RealRelianceBanking.Application.Contact.Commands;
@@ -6,7 +7,8 @@ using RealRelianceBanking.Application.Contact.Commands;
 namespace RealRelianceBankingAPI.Controllers.Contact
 {
     [ApiController]
-    [Route("api/[controller]")]
+    [ApiVersion("1.0")]
+    [Route("api/v{version:apiVersion}/[controller]")]
     public class ContactController : ControllerBase
     {
         private readonly IMediator _mediator;

--- a/RealRelianceBankingAPI/Controllers/Person/PersonController.cs
+++ b/RealRelianceBankingAPI/Controllers/Person/PersonController.cs
@@ -1,4 +1,5 @@
-﻿using MediatR;
+﻿using Asp.Versioning;
+using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using RealRelianceBanking.Application.Person.Command.CreatePerson;
@@ -12,7 +13,8 @@ using RealRelianceBanking.Application.Person.Queries.SearchPersons;
 
 namespace RealRelianceBankingAPI.Controllers.Person
 {
-    [Route("api/[controller]")]
+    [ApiVersion("1.0")]
+    [Route("api/v{version:apiVersion}/[controller]")]
     [ApiController]
     [Authorize]
     public class PersonsController : ControllerBase

--- a/RealRelianceBankingAPI/Controllers/Transaction/TransactionController.cs
+++ b/RealRelianceBankingAPI/Controllers/Transaction/TransactionController.cs
@@ -1,4 +1,5 @@
-﻿using MediatR;
+﻿using Asp.Versioning;
+using MediatR;
 using Microsoft.AspNetCore.Mvc;
 using RealRelianceBanking.Application.Transactions.Queries.GetAccountTransactions;
 using RealRelianceBanking.Application.Transactions.Queries.GetTransactions;
@@ -11,7 +12,8 @@ using RealRelianceBanking.Application.Transactions.Command.Create;
 
 namespace RealRelianceBankingAPI.Controllers.Transaction
 {
-    [Route("api/[controller]")]
+    [ApiVersion("1.0")]
+    [Route("api/v{version:apiVersion}/[controller]")]
     [ApiController]
     [Authorize]
     public class TransactionController : ControllerBase

--- a/RealRelianceBankingAPI/Program.cs
+++ b/RealRelianceBankingAPI/Program.cs
@@ -1,9 +1,14 @@
 using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Asp.Versioning;
+using Asp.Versioning.ApiExplorer;
 using Microsoft.IdentityModel.Tokens;
+using Microsoft.Extensions.Options;
 using Microsoft.OpenApi.Models;
 using RealRelianceBanking.Application;
 using RealRelianceBanking.Infrastructure;
 using RealRelianceBankingAPI;
+using RealRelianceBankingAPI.Common;
+using Swashbuckle.AspNetCore.SwaggerGen;
 using System.Text;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -39,15 +44,23 @@ if (!builder.Services.Any(x => x.ServiceType == typeof(Microsoft.AspNetCore.Auth
 
 builder.Services.AddAuthorization();
 
+builder.Services.AddApiVersioning(options =>
+{
+    options.DefaultApiVersion = new ApiVersion(1, 0);
+    options.AssumeDefaultVersionWhenUnspecified = true;
+    options.ReportApiVersions = true;
+    options.ApiVersionReader = new UrlSegmentApiVersionReader();
+});
+builder.Services.AddVersionedApiExplorer(options =>
+{
+    options.GroupNameFormat = "'v'VVV";
+    options.SubstituteApiVersionInUrl = true;
+});
+
 builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddTransient<IConfigureOptions<SwaggerGenOptions>, ConfigureSwaggerOptions>();
 builder.Services.AddSwaggerGen(options =>
 {
-    options.SwaggerDoc("v1", new OpenApiInfo
-    {
-        Title = "RealReliance Bank API",
-        Version = "v1"
-    });
-
     options.AddSecurityDefinition("Bearer", new OpenApiSecurityScheme
     {
         Name = "Authorization",
@@ -86,13 +99,18 @@ builder.Services.AddCors(options =>
 });
 
 var app = builder.Build();
+var apiVersionDescriptionProvider = app.Services.GetRequiredService<IApiVersionDescriptionProvider>();
 
 if (app.Environment.IsDevelopment())
 {
     app.UseSwagger();
     app.UseSwaggerUI(c =>
     {
-        c.SwaggerEndpoint("/swagger/v1/swagger.json", "RealRelianceBank API v1");
+        foreach (var description in apiVersionDescriptionProvider.ApiVersionDescriptions)
+        {
+            c.SwaggerEndpoint($"/swagger/{description.GroupName}/swagger.json",
+                $"RealReliance Bank API {description.GroupName.ToUpperInvariant()}");
+        }
         c.DisplayRequestDuration();
     });
 }

--- a/RealRelianceBankingAPI/RealRelianceBankingAPI.csproj
+++ b/RealRelianceBankingAPI/RealRelianceBankingAPI.csproj
@@ -7,6 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Asp.Versioning.Mvc" Version="7.1.0" />
+    <PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" Version="7.1.0" />
     <PackageReference Include="Mapster" Version="7.3.0" />
     <PackageReference Include="Mapster.DependencyInjection" Version="1.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="7.0.20" />


### PR DESCRIPTION
### Motivation

- Prepare the API for future growth by introducing explicit versioning so breaking changes can be rolled out safely.
- Provide versioned OpenAPI documentation so clients can discover endpoints per API version.

### Description

- Add `Asp.Versioning.Mvc` and `Asp.Versioning.Mvc.ApiExplorer` package references in `RealRelianceBankingAPI.csproj` to enable API versioning and explorer integration.
- Configure API versioning and versioned API explorer in `Program.cs` using URL-segment versioning with `UrlSegmentApiVersionReader` and default version `1.0`.
- Add `RealRelianceBankingAPI/Common/ConfigureSwaggerOptions.cs` to register Swagger documents for each API version from the `IApiVersionDescriptionProvider`.
- Update controllers to declare `[ApiVersion("1.0")]` and use the route template `api/v{version:apiVersion}/[controller]`, and update SwaggerUI setup to expose all discovered versioned docs.

### Testing

- No automated tests were run on the modified code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697c7bb802148330937234da707695a9)